### PR TITLE
Add Elasticsearch7 to search scheme

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -43,6 +43,7 @@ Supported types
   * Elasticsearch: ``elasticsearch://``
   * Elasticsearch2: ``elasticsearch2://``
   * Elasticsearch5: ``elasticsearch5://``
+  * Elasticsearch7: ``elasticsearch7://``
   * Solr: ``solr://``
   * Whoosh: ``whoosh://``
   * Xapian: ``xapian://``

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -159,6 +159,7 @@ class Env:
         'elasticsearch',
         'elasticsearch2',
         'elasticsearch5',
+        'elasticsearch7',
     ]
 
     SEARCH_SCHEMES = {
@@ -168,6 +169,8 @@ class Env:
                           'Elasticsearch2SearchEngine',
         'elasticsearch5': 'haystack.backends.elasticsearch5_backend.'
                           'Elasticsearch5SearchEngine',
+        'elasticsearch7': 'haystack.backends.elasticsearch7_backend.'
+                          'Elasticsearch7SearchEngine',
         'solr': 'haystack.backends.solr_backend.SolrEngine',
         'whoosh': 'haystack.backends.whoosh_backend.WhooshEngine',
         'xapian': 'haystack.backends.xapian_backend.XapianEngine',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ def volume():
     'elasticsearch://127.0.0.1:9200/index',
     'elasticsearch2://127.0.0.1:9200/index',
     'elasticsearch5://127.0.0.1:9200/index',
+    'elasticsearch7://127.0.0.1:9200/index',
     'whoosh:///home/search/whoosh_index',
     'xapian:///home/search/xapian_index',
     'simple:///'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -41,6 +41,8 @@ def test_solr_multicore_parsing(solr_url):
          'haystack.backends.elasticsearch2_backend.Elasticsearch2SearchEngine'),  # noqa: E501
         ('elasticsearch5://127.0.0.1:9200/index',
          'haystack.backends.elasticsearch5_backend.Elasticsearch5SearchEngine'),  # noqa: E501
+        ('elasticsearch7://127.0.0.1:9200/index',
+         'haystack.backends.elasticsearch7_backend.Elasticsearch7SearchEngine'),  # noqa: E501
     ],
 )
 def test_elasticsearch_parsing(url, engine):


### PR DESCRIPTION
The Elasticsearch7 backend has been added in haystack v3.1.0
https://github.com/django-haystack/django-haystack/releases/tag/v3.1.0

---

...I haven't modified the changelog.